### PR TITLE
Fix the bug in Tag Menu Edit Modal.

### DIFF
--- a/client/js/tags/MenusDialog.jsx
+++ b/client/js/tags/MenusDialog.jsx
@@ -5,7 +5,7 @@ import Select2Input from '../Select2Input';
 
 export default class MenusDialog extends React.Component {
   renderBody() {
-    const { tagId, loading, selected, data, onAdd, onDelete } = this.props;
+    const { tagId, loading, selected, data, disabled, onAdd, onDelete } = this.props;
 
     if (loading) {
       return <p>불러오는 중입니다...</p>;
@@ -16,6 +16,7 @@ export default class MenusDialog extends React.Component {
         id="menuSelect"
         value={loading ? [] : selected}
         data={data}
+        disabled={disabled}
         multiple
         placeholder="권한 추가하기"
         onAdd={id => onAdd(tagId, id)}
@@ -43,11 +44,16 @@ export default class MenusDialog extends React.Component {
   }
 }
 
+MenusDialog.defaultProps = {
+  disabled: false,
+};
+
 MenusDialog.propTypes = {
   tagId: PropTypes.number.isRequired,
   show: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
   selected: PropTypes.arrayOf(PropTypes.number).isRequired,
+  disabled: PropTypes.bool,
   data: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.oneOfType([
       PropTypes.string,

--- a/client/js/tags/TagEdit.jsx
+++ b/client/js/tags/TagEdit.jsx
@@ -53,6 +53,7 @@ export default class TagEdit extends React.Component {
       menus: [],
       menusTag: 0,
       menusLoading: true,
+      menusDisabled: true,
       showMenusDlg: false,
       users: [],
       usersLoading: true,
@@ -70,11 +71,14 @@ export default class TagEdit extends React.Component {
       this.setState(Object.assign({}, this.state, {
         menus: returnData.data.menus,
         menusLoading: false,
+        menusDisabled: false,
       }));
     }, 'json');
   }
 
   handleAddMenu(tagId, menuId) {
+    this.setState({ menusDisabled: true });
+
     $.ajax({
       url: `/super/tags/${tagId}/menus/${menuId}`,
       type: 'PUT',
@@ -85,7 +89,7 @@ export default class TagEdit extends React.Component {
 
         const newTags = this.state.tags.map((tag) => {
           let result = tag;
-          if (tag.id === tagId) {
+          if (tag.id === parseInt(tagId, 10)) {
             result = Object.assign({}, tag, {
               menus_count: tag.menus_count + 1,
             });
@@ -95,7 +99,7 @@ export default class TagEdit extends React.Component {
 
         const newMenu = this.state.menus.map((menu) => {
           let result = menu;
-          if (menu.id === menuId) {
+          if (menu.id === parseInt(menuId, 10)) {
             result = Object.assign({}, menu, {
               selected: 'selected',
             });
@@ -103,22 +107,24 @@ export default class TagEdit extends React.Component {
           return result;
         });
 
-        this.setState(Object.assign({}, this.state, {
+        this.setState({
+          menusDisabled: false,
           tags: newTags,
           menus: newMenu,
-        }));
+        });
       },
     });
   }
 
   handleDeleteMenu(tagId, menuId) {
+    this.setState({ menusDisabled: true });
     $.ajax({
       url: `/super/tags/${tagId}/menus/${menuId}`,
       type: 'DELETE',
       success: () => {
         const newTags = this.state.tags.map((tag) => {
           let result = tag;
-          if (tag.id === tagId) {
+          if (tag.id === parseInt(tagId, 10)) {
             result = Object.assign({}, tag, {
               menus_count: tag.menus_count - 1,
             });
@@ -128,7 +134,7 @@ export default class TagEdit extends React.Component {
 
         const newMenu = this.state.menus.map((menu) => {
           let result = menu;
-          if (menu.id === menuId) {
+          if (menu.id === parseInt(menuId, 10)) {
             result = Object.assign({}, menu, {
               selected: null,
             });
@@ -137,6 +143,7 @@ export default class TagEdit extends React.Component {
         });
 
         this.setState(Object.assign({}, this.state, {
+          menusDisabled: false,
           tags: newTags,
           menus: newMenu,
         }));
@@ -207,7 +214,7 @@ export default class TagEdit extends React.Component {
   }
 
   render() {
-    const { tags, menus, menusTag, menusLoading, showMenusDlg, users, usersLoading, showUsersDlg } = this.state;
+    const { tags, menus, menusTag, menusLoading, menusDisabled, showMenusDlg, users, usersLoading, showUsersDlg } = this.state;
 
     users.sort((a, b) => {
       if (a.name > b.name) return 1;
@@ -245,6 +252,7 @@ export default class TagEdit extends React.Component {
           loading={menusLoading}
           data={menuDatas}
           selected={menuSelected}
+          disabled={menusDisabled}
           onAdd={this.handleAddMenu}
           onDelete={this.handleDeleteMenu}
           onClose={this.handleMenusDlgClose}


### PR DESCRIPTION
### 이슈:
https://app.asana.com/0/235684600038401/414091913745078/f
태그 편집 페이지에서 태그에 포함할 메뉴를 추가/삭제하면 제대로 동작하지 않습니다.
(확인해보니 계속 추가 삭제하다보면 select2에 나온 내용과 실제 DB데이터가 일치하지 않아서 혼란스럽습니다.)

### 원인: 
추가/삭제된 menuId를 select2에 적용하는 부분에서 number타입과 string타입을 ===로 비교하는 부분이 문제입니다. eslint를 적용하면서 타입이 다른 것을 인지못하고 ==를 ===로 변경하면서 발생한 버그인 듯 합니다.

버그 수정 외에도 ajax 요청이 완료될 때까지 select2를 disabled하게 만들어 변경 중에 또다른 변경이 일어나지 않도록 변경했습니다.

### 확인 방법:
- 변경 적용하지 전:
  - Tag편집 페이지에서 Menu를 가지고 있지 않은 빈 Tag에 Menu를 2개 추가해보고, 다시 추가한 2개를 제거해본다.
  - 마지막 Menu 제거 시 그 전에 제거한 Menu가 재생성된다. (UI에만 그렇게 보이고 새로고침하면 제거되어 있음)
- 변경 적용 후:
  - 위 현상이 해결됨