### PR TITLE
Remove the platform in namespaces.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Ridibooks\\Platform\\Cms\\Admin\\": "server/src/Admin"
+      "Ridibooks\\Cms\\Admin\\": "server/src/Admin"
     }
   }
 }

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
-use Ridibooks\Platform\Cms\Admin\CmsAdminApplication;
+use Ridibooks\Cms\Admin\CmsAdminApplication;
 use Ridibooks\Cms\Thrift\ThriftService;
 use Ridibooks\Platform\Cms\Auth\LoginService;
 

--- a/server/src/Admin/CmsAdminApplication.php
+++ b/server/src/Admin/CmsAdminApplication.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
 
-namespace Ridibooks\Platform\Cms\Admin;
+namespace Ridibooks\Cms\Admin;
 
 use Moriony\Silex\Provider\SentryServiceProvider;
-use Ridibooks\Platform\Cms\Admin\Controller\LogControllerProvider as AdminLogController;
-use Ridibooks\Platform\Cms\Admin\Controller\MenuControllerProvider as AdminMenuController;
-use Ridibooks\Platform\Cms\Admin\Controller\TagControllerProvider as AdminTagController;
-use Ridibooks\Platform\Cms\Admin\Controller\UserControllerProvider as AdminUserController;
+use Ridibooks\Cms\Admin\Controller\LogControllerProvider as AdminLogController;
+use Ridibooks\Cms\Admin\Controller\MenuControllerProvider as AdminMenuController;
+use Ridibooks\Cms\Admin\Controller\TagControllerProvider as AdminTagController;
+use Ridibooks\Cms\Admin\Controller\UserControllerProvider as AdminUserController;
 use Ridibooks\Platform\Cms\CmsApplication;
 use Ridibooks\Platform\Cms\MiniRouter;
 use Symfony\Component\Asset\PathPackage;

--- a/server/src/Admin/Controller/LogControllerProvider.php
+++ b/server/src/Admin/Controller/LogControllerProvider.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Ridibooks\Platform\Cms\Admin\Controller;
+namespace Ridibooks\Cms\Admin\Controller;
 
-use Ridibooks\Platform\Cms\Admin\LogService;
-use Ridibooks\Platform\Cms\Admin\Model\AdminUserPermissionLog;
+use Ridibooks\Cms\Admin\LogService;
+use Ridibooks\Cms\Admin\Model\AdminUserPermissionLog;
 use Ridibooks\Platform\Cms\CmsApplication;
 use Silex\Api\ControllerProviderInterface;
 use Silex\Application;

--- a/server/src/Admin/Controller/MenuControllerProvider.php
+++ b/server/src/Admin/Controller/MenuControllerProvider.php
@@ -1,8 +1,8 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin\Controller;
+namespace Ridibooks\Cms\Admin\Controller;
 
 use Moriony\Silex\Provider\SentryServiceProvider;
-use Ridibooks\Platform\Cms\Admin\MenuService as AdminMenuService;
+use Ridibooks\Cms\Admin\MenuService as AdminMenuService;
 use Ridibooks\Platform\Cms\CmsApplication;
 use Silex\Api\ControllerProviderInterface;
 use Silex\Application;

--- a/server/src/Admin/Controller/TagControllerProvider.php
+++ b/server/src/Admin/Controller/TagControllerProvider.php
@@ -1,8 +1,8 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin\Controller;
+namespace Ridibooks\Cms\Admin\Controller;
 
 use Moriony\Silex\Provider\SentryServiceProvider;
-use Ridibooks\Platform\Cms\Admin\TagService as AdminTagService;
+use Ridibooks\Cms\Admin\TagService as AdminTagService;
 use Ridibooks\Platform\Cms\CmsApplication;
 use Silex\Api\ControllerProviderInterface;
 use Silex\Application;

--- a/server/src/Admin/Controller/UserControllerProvider.php
+++ b/server/src/Admin/Controller/UserControllerProvider.php
@@ -1,8 +1,8 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin\Controller;
+namespace Ridibooks\Cms\Admin\Controller;
 
-use Ridibooks\Platform\Cms\Admin\LogService as AdminLogService;
-use Ridibooks\Platform\Cms\Admin\UserService as AdminUserService;
+use Ridibooks\Cms\Admin\LogService as AdminLogService;
+use Ridibooks\Cms\Admin\UserService as AdminUserService;
 use Ridibooks\Platform\Cms\CmsApplication;
 use Silex\Api\ControllerProviderInterface;
 use Silex\Application;

--- a/server/src/Admin/LogService.php
+++ b/server/src/Admin/LogService.php
@@ -1,9 +1,9 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin;
+namespace Ridibooks\Cms\Admin;
 
 use Illuminate\Database\Capsule\Manager as DB;
-use Ridibooks\Platform\Cms\Admin\Model\AdminUser;
-use Ridibooks\Platform\Cms\Admin\Model\AdminUserPermissionLog;
+use Ridibooks\Cms\Admin\Model\AdminUser;
+use Ridibooks\Cms\Admin\Model\AdminUserPermissionLog;
 use Ridibooks\Platform\Cms\Auth\LoginService;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 

--- a/server/src/Admin/MenuService.php
+++ b/server/src/Admin/MenuService.php
@@ -1,9 +1,9 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin;
+namespace Ridibooks\Cms\Admin;
 
 use Illuminate\Database\Capsule\Manager as DB;
-use Ridibooks\Platform\Cms\Admin\Model\AdminMenu;
-use Ridibooks\Platform\Cms\Admin\Model\AdminMenuAjax;
+use Ridibooks\Cms\Admin\Model\AdminMenu;
+use Ridibooks\Cms\Admin\Model\AdminMenuAjax;
 
 class MenuService
 {

--- a/server/src/Admin/Model/AdminMenu.php
+++ b/server/src/Admin/Model/AdminMenu.php
@@ -1,5 +1,5 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin\Model;
+namespace Ridibooks\Cms\Admin\Model;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/server/src/Admin/Model/AdminMenuAjax.php
+++ b/server/src/Admin/Model/AdminMenuAjax.php
@@ -1,5 +1,5 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin\Model;
+namespace Ridibooks\Cms\Admin\Model;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/server/src/Admin/Model/AdminTag.php
+++ b/server/src/Admin/Model/AdminTag.php
@@ -1,5 +1,5 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin\Model;
+namespace Ridibooks\Cms\Admin\Model;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/server/src/Admin/Model/AdminUser.php
+++ b/server/src/Admin/Model/AdminUser.php
@@ -1,5 +1,5 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin\Model;
+namespace Ridibooks\Cms\Admin\Model;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/server/src/Admin/Model/AdminUserPermissionLog.php
+++ b/server/src/Admin/Model/AdminUserPermissionLog.php
@@ -1,5 +1,5 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin\Model;
+namespace Ridibooks\Cms\Admin\Model;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/server/src/Admin/TagService.php
+++ b/server/src/Admin/TagService.php
@@ -1,7 +1,7 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin;
+namespace Ridibooks\Cms\Admin;
 
-use Ridibooks\Platform\Cms\Admin\Model\AdminTag;
+use Ridibooks\Cms\Admin\Model\AdminTag;
 use Ridibooks\Platform\Cms\Auth\LoginService;
 
 class TagService

--- a/server/src/Admin/UserService.php
+++ b/server/src/Admin/UserService.php
@@ -1,7 +1,7 @@
 <?php
-namespace Ridibooks\Platform\Cms\Admin;
+namespace Ridibooks\Cms\Admin;
 
-use Ridibooks\Platform\Cms\Admin\Model\AdminUser;
+use Ridibooks\Cms\Admin\Model\AdminUser;
 use Ridibooks\Platform\Cms\Auth\PasswordService;
 
 class UserService

--- a/server/src/Admin/WebpackManifestVersionStrategy.php
+++ b/server/src/Admin/WebpackManifestVersionStrategy.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Ridibooks\Platform\Cms\Admin;
+namespace Ridibooks\Cms\Admin;
 
 use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
 


### PR DESCRIPTION
This project is not Platform team's anymore, so remove Platform word from the namespaces.
(But `cms-sdk` uses 'Platform' too, so not completed removed.)