### PR TITLE
Change tmp mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   web:
     image: ${DOCKER_REPO}:${DOCKER_TAG}
     volumes:
-      - /tmp/cms-admin:/tmp
+      - /tmp:/tmp
     ports:
       - ${DOCKER_PUBLISH_PORT}:80
     cpu_shares: 100


### PR DESCRIPTION
https://sentry.io/ridi/cms-admin/issues/407369940
/tmp/cms-admin에 대한 권한 부족으로, 우선 모든 권한이 있는 /tmp경로로 변경했습니다.